### PR TITLE
MVP-002: add local PostgreSQL baseline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+POSTGRES_DB=personal_crm
+POSTGRES_USER=personal_crm
+POSTGRES_PASSWORD=personal_crm
+POSTGRES_PORT=5432
+DATABASE_URL=postgresql://personal_crm:personal_crm@localhost:5432/personal_crm

--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,9 @@ POSTGRES_DB=personal_crm
 POSTGRES_USER=personal_crm
 POSTGRES_PASSWORD=personal_crm
 POSTGRES_PORT=5432
-DATABASE_URL=postgresql://personal_crm:personal_crm@localhost:5432/personal_crm
+
+# Add DATABASE_URL when the application runtime is wired.
+# Keep it derived from the POSTGRES_* variables above instead of maintaining
+# an independent set of credentials.
+# Example:
+# DATABASE_URL=postgresql://personal_crm:personal_crm@localhost:5432/personal_crm

--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,4 @@ POSTGRES_DB=personal_crm
 POSTGRES_USER=personal_crm
 POSTGRES_PASSWORD=personal_crm
 POSTGRES_PORT=5432
-
-# Add DATABASE_URL when the application runtime is wired.
-# Keep it derived from the POSTGRES_* variables above instead of maintaining
-# an independent set of credentials.
-# Example:
-# DATABASE_URL=postgresql://personal_crm:personal_crm@localhost:5432/personal_crm
+DATABASE_URL=postgresql://personal_crm:personal_crm@localhost:5432/personal_crm

--- a/README.md
+++ b/README.md
@@ -36,8 +36,4 @@ Project planning and architecture documentation live in [project/README.md](proj
 5. Reset the local database volume:
    - `pnpm db:reset`
 
-The local database runs PostgreSQL 18 through Docker Compose.
-
-`POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_PORT` are the source of truth in the root `.env` file.
-
-Add `DATABASE_URL` only when the application runtime is wired, and keep it derived from those PostgreSQL variables rather than maintaining a second independent set of credentials.
+The local database runs PostgreSQL 18 through Docker Compose and expects `DATABASE_URL` in the root `.env` file.

--- a/README.md
+++ b/README.md
@@ -36,4 +36,8 @@ Project planning and architecture documentation live in [project/README.md](proj
 5. Reset the local database volume:
    - `pnpm db:reset`
 
-The local database runs PostgreSQL 18 through Docker Compose and expects `DATABASE_URL` in the root `.env` file.
+The local database runs PostgreSQL 18 through Docker Compose.
+
+`POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_PORT` are the source of truth in the root `.env` file.
+
+Add `DATABASE_URL` only when the application runtime is wired, and keep it derived from those PostgreSQL variables rather than maintaining a second independent set of credentials.

--- a/README.md
+++ b/README.md
@@ -22,3 +22,18 @@ Project planning and architecture documentation live in [project/README.md](proj
 - Repo-wide code quality commands run directly at the root against the shared Biome and Ultracite config: `pnpm check`, `pnpm fix`, and `pnpm format`.
 - To run a task for one package, prefer `turbo run <task> --filter=<package>` or `pnpm --filter <package> <task>`.
 - CI should prefer non-mutating root commands: `pnpm check`, `pnpm typecheck`, `pnpm test`, and `pnpm build`.
+
+## Local Database
+
+1. Copy the local environment template:
+   - `cp .env.example .env`
+2. Start PostgreSQL:
+   - `pnpm db:up`
+3. Stream database logs:
+   - `pnpm db:logs`
+4. Stop local services:
+   - `pnpm db:down`
+5. Reset the local database volume:
+   - `pnpm db:reset`
+
+The local database runs PostgreSQL 18 through Docker Compose and expects `DATABASE_URL` in the root `.env` file.

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,21 @@
+services:
+  postgres:
+    image: postgres:18
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      PGDATA: /var/lib/postgresql/18/docker
+    volumes:
+      - postgres_data:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+
+volumes:
+  postgres_data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,7 +7,6 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      PGDATA: /var/lib/postgresql/18/docker
     volumes:
       - postgres_data:/var/lib/postgresql
     healthcheck:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,11 @@
     "format": "biome format --write .",
     "check": "ultracite check .",
     "test": "turbo run test",
-    "typecheck": "turbo run typecheck"
+    "typecheck": "turbo run typecheck",
+    "db:up": "docker compose up -d postgres",
+    "db:down": "docker compose down",
+    "db:reset": "docker compose down -v",
+    "db:logs": "docker compose logs -f postgres"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.0",


### PR DESCRIPTION
## Summary
- add a minimal local PostgreSQL runtime with Docker Compose
- add root environment template and database helper scripts
- document the local database workflow in the root README

## Included
- `compose.yaml` with a single `postgres` service
- PostgreSQL 18 with PG18-compatible `PGDATA`
- `pg_isready` healthcheck
- root `.env.example`
- root scripts: `db:up`, `db:down`, `db:reset`, `db:logs`
- README instructions for local database startup and reset

## Validation
- `pnpm check`
- `pnpm db:up`
- `docker compose ps`
- `docker compose exec postgres pg_isready -U personal_crm -d personal_crm`
- `pnpm db:down`

## Notes
- this PR does not add application-level database connection code yet
- connection conventions are prepared through `DATABASE_URL`
- closes #13
